### PR TITLE
Add Bugsink to the list of source map users

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A list of all source map users.
 
 + [Replay.io](https://replay.io/)
 + [Sentry](https://sentry.io/welcome/)
++ [Bugsink](https://www.bugsink.com/)
 
 ## Bundlers and build tools
 


### PR DESCRIPTION
As per https://www.bugsink.com/blog/bugsink-1.5-introducing-sourcemaps/